### PR TITLE
Fix snapclient COPY source path (real build caught the bug)

### DIFF
--- a/mr-do-snapclient/Dockerfile
+++ b/mr-do-snapclient/Dockerfile
@@ -52,7 +52,7 @@ RUN apk add --no-cache \
         libstdc++ \
         libvorbis
 
-COPY --from=snapclient /root/snapcast/bin/snapclient /usr/local/bin/
+COPY --from=snapclient /snapcast/bin/snapclient /usr/local/bin/
 
 ENV DEVICE_NAME=mr-do-snapclient
 

--- a/mr-do-snapserver/Dockerfile
+++ b/mr-do-snapserver/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
+# librespot-org/librespot has its own default branch (NOT snapcast)
 RUN git clone --depth 1 https://github.com/librespot-org/librespot.git && \
     cd librespot && \
     cargo build --release --no-default-features \


### PR DESCRIPTION
Found by running docker buildx on mr-beelink: snapclient build failed at the final stage with:
  failed to calculate checksum of ref: /root/snapcast/bin/snapclient: not found

The previous Dockerfile had WORKDIR /root in the snapclient build stage, and my earlier rewrite dropped it without updating the COPY paths. With no WORKDIR the build stage defaults to /, and cmake drops the binary at /snapcast/bin/snapclient. snapserver uses the same pattern (no WORKDIR) and its COPY at 'snapcast/bin/snapserver' is the correct relative form under WORKDIR=/. snapclient now matches.

mr-do-snapclient local image: 28.2 MB, runs snapclient v0.35.0
mr-do-snapserver local image: 65.2 MB, runs snapserver v0.35.0

Also: comment clarification on snapserver librespot stage.

Builds executed via mr-beelink (192.168.0.242, Docker 29.1.3 + buildx 0.35.0, multi-stage cmake).