### PR TITLE
Pin librespot-org/librespot to its dev branch

### DIFF
--- a/mr-do-snapserver/Dockerfile
+++ b/mr-do-snapserver/Dockerfile
@@ -13,8 +13,11 @@ RUN apk add --no-cache \
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-# librespot-org/librespot has its own default branch (NOT snapcast)
-RUN git clone --depth 1 https://github.com/librespot-org/librespot.git && \
+# librespot-org/librespot 'dev' branch is the only maintained line
+# (master/main no longer tracked upstream). Override via --build-arg LIBRESPOT_VERSION=dev
+ARG LIBRESPOT_VERSION=dev
+RUN git clone --depth 1 --branch ${LIBRESPOT_VERSION} \
+        https://github.com/librespot-org/librespot.git && \
     cd librespot && \
     cargo build --release --no-default-features \
         --features "with-libmdns,rustls-tls-native-roots"

--- a/mr-do-snapserver/build.sh
+++ b/mr-do-snapserver/build.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SNAPCAST_VERSION="${SNAPCAST_VERSION:-develop}"
+LIBRESPOT_VERSION="${LIBRESPOT_VERSION:-dev}"
 IMAGE="riemerk/mr-do-snapserver"
 
 echo "Building ${IMAGE} (snapcast ${SNAPCAST_VERSION})"
@@ -9,6 +10,7 @@ echo "Building ${IMAGE} (snapcast ${SNAPCAST_VERSION})"
 docker buildx build \
     --tag "${IMAGE}:latest" \
     --build-arg SNAPCAST_VERSION="${SNAPCAST_VERSION}" \
+    --build-arg LIBRESPOT_VERSION="${LIBRESPOT_VERSION}" \
     .
 
 # Tag the version if the binary can report one


### PR DESCRIPTION
librespot-org/librespot no longer tracks master/main upstream (only the dev branch remains). Switch the snapserver librespot stage to clone from dev (with ARG LIBRESPOT_VERSION=dev for override-ability, mirroring the existing SNAPCAST_VERSION pattern in build.sh).

Verified by real docker buildx on mr-beelink (2026-07-07): binary reports 'librespot 0.8.0 db1ef7a ...' which matches the tip of refs/heads/dev.