### PR TITLE
fix(app): move ignoreDifferences from syncPolicy to top-level spec

### DIFF
--- a/mr-do-player/kubernetes/application.yaml
+++ b/mr-do-player/kubernetes/application.yaml
@@ -39,16 +39,16 @@ spec:
       - ApplyOutOfSyncOnly=true
       - PruneLast=true
       - PrunePropagationPolicy=foreground
-    ignoreDifferences:
-      # ArgoCD fights runtime-assigned fields on LoadBalancer Services
-      - group: ""
-        kind: Service
-        name: mr-do-player-service
-        jsonPointers:
-          - /status
-          - /spec/clusterIP
-          - /spec/clusterIPs
-          - /spec/externalTrafficPolicy
-          - /spec/ipFamilyPolicy
-          - /spec/ipFamilies
-          - /spec/sessionAffinity
+  ignoreDifferences:
+    # ArgoCD fights runtime-assigned fields on LoadBalancer Services
+    - group: ""
+      kind: Service
+      name: mr-do-player-service
+      jsonPointers:
+        - /status
+        - /spec/clusterIP
+        - /spec/clusterIPs
+        - /spec/externalTrafficPolicy
+        - /spec/ipFamilyPolicy
+        - /spec/ipFamilies
+        - /spec/sessionAffinity


### PR DESCRIPTION
## Problem

ArgoCD Application mr-do-player has Sync Status: Unknown with a ComparisonError:



In ArgoCD 3.x, ignoreDifferences is a top-level spec field, NOT nested under syncPolicy. The current main commit (2166164) puts it under syncPolicy, which the schema rejects.

## Fix

Move ignoreDifferences to the top level of spec (per CRD).

## Verification

After merge, ArgoCD will:
1. Stop emitting ComparisonError
2. Begin reconciling against current main
3. Show real drift status (the live Deployment/Service are from an old revision; further fix in next PR)
