### PR TITLE
fix(app): set kustomize.version to v5.8.1

### DIFF
--- a/mr-do-player/kubernetes/application.yaml
+++ b/mr-do-player/kubernetes/application.yaml
@@ -19,7 +19,7 @@ spec:
     kustomize:
       # kustomization.yaml in path roots every resource by kind-suffixed name
       # (e.g. deployment.yaml, service.yaml). No patches / overlays today.
-      version: v1
+      version: v5.8.1
   destination:
     server: https://kubernetes.default.svc
     namespace: mr-do-player


### PR DESCRIPTION
## Problem

ArgoCD 3.3.3 ships kustomize v5.8.1 but the manifest declares version: v1, which is not in ArgoCD's kustomize version registry. This causes ComparisonError:
```
kustomize version v1 is not registered
```

## Fix

Set version to v5.8.1 (matches the installed binary).

## Note

This is the third fix in a sequence: PR #7 moved ignoreDifferences to top level. This PR fixes kustomize.version. After both merges, ArgoCD should successfully render manifests and report real drift (port name too long, selector immutable — to be addressed in a follow-up).