### PR TITLE
fix(app): move ignoreDifferences from syncPolicy to top-level spec

### DIFF
--- a/mr-do-player/kubernetes/application.yaml
+++ b/mr-do-player/kubernetes/application.yaml
@@ -39,16 +39,16 @@ spec:
       - ApplyOutOfSyncOnly=true
       - PruneLast=true
       - PrunePropagationPolicy=foreground
-    ignoreDifferences:
-      # ArgoCD fights runtime-assigned fields on LoadBalancer Services
-      - group: ""
-        kind: Service
-        name: mr-do-player-service
-        jsonPointers:
-          - /status
-          - /spec/clusterIP
-          - /spec/clusterIPs
-          - /spec/externalTrafficPolicy
-          - /spec/ipFamilyPolicy
-          - /spec/ipFamilies
-          - /spec/sessionAffinity
+  ignoreDifferences:
+    # ArgoCD fights runtime-assigned fields on LoadBalancer Services
+    - group: ""
+      kind: Service
+      name: mr-do-player-service
+      jsonPointers:
+        - /status
+        - /spec/clusterIP
+        - /spec/clusterIPs
+        - /spec/externalTrafficPolicy
+        - /spec/ipFamilyPolicy
+        - /spec/ipFamilies
+        - /spec/sessionAffinity


### PR DESCRIPTION
ArgoCD 3.x rejects Application specs that nest ignoreDifferences under syncPolicy — schema validation fails with
'.spec.syncPolicy.ignoreDifferences: field not declared in schema', which broke reconciliation entirely (Sync Status: Unknown, Condition: ComparisonError).

Fix is to declare ignoreDifferences at the top level of spec, which is the correct schema location.