### PR TITLE
fix(app): set kustomize.version to v5.8.1 to match installed binary

### DIFF
--- a/mr-do-player/kubernetes/application.yaml
+++ b/mr-do-player/kubernetes/application.yaml
@@ -19,7 +19,7 @@ spec:
     kustomize:
       # kustomization.yaml in path roots every resource by kind-suffixed name
       # (e.g. deployment.yaml, service.yaml). No patches / overlays today.
-      version: v1
+      version: v5.8.1
   destination:
     server: https://kubernetes.default.svc
     namespace: mr-do-player


### PR DESCRIPTION
ArgoCD 3.3.3 ships kustomize v5.8.1. The previous version: v1 was not in ArgoCD's kustomize version registry, causing 'kustomize version v1 is not registered' error.