### PR TITLE
fix(player): rename port name snapcast-control to snapcast-ctrl

### DIFF
--- a/mr-do-player/kubernetes/deployment.yaml
+++ b/mr-do-player/kubernetes/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - containerPort: 1704
               name: snapcast-stream
             - containerPort: 1705
-              name: snapcast-control
+              name: snapcast-ctrl
             # librespot zeroconf port (set via snapserver.conf params)
             - containerPort: 42661
               name: librespot

--- a/mr-do-player/kubernetes/service.yaml
+++ b/mr-do-player/kubernetes/service.yaml
@@ -43,7 +43,7 @@ spec:
     - port: 1705
       targetPort: snapcast-control
       protocol: TCP
-      name: snapcast-control
+      name: snapcast-ctrl
     # --- librespot zeroconf (Spotify Connect) ---
     - port: 42661
       targetPort: librespot


### PR DESCRIPTION
Kubernetes port names are capped at 15 characters; snapcast-control is 16. Rename to snapcast-ctrl (13 chars) in both deployment.yaml and service.yaml so ArgoCD can recreate the live Deployment (selector changed, old immutable).