### PR TITLE
fix(player): snapserver mount path for runAsUser 1000

### DIFF
--- a/mr-do-player/kubernetes/deployment.yaml
+++ b/mr-do-player/kubernetes/deployment.yaml
@@ -157,7 +157,7 @@ spec:
           volumeMounts:
             # Requires /srv/nfs4/homes/mr/media/snapserver/ to exist on NFS
             - name: player-data
-              mountPath: /root/.config/snapserver
+              mountPath: /home/snapserver/.config/snapserver
               subPath: snapserver
             - name: snapserver-config
               mountPath: /etc/snapserver.conf


### PR DESCRIPTION
snapserver was failing EROFS because the new runAsUser 1000 security hardening could not write to /root. Move mount to /home/snapserver.