### PR TITLE
fix(player): merge HOME env into snapserver env block

### DIFF
--- a/mr-do-player/kubernetes/deployment.yaml
+++ b/mr-do-player/kubernetes/deployment.yaml
@@ -110,12 +110,6 @@ spec:
         - name: mr-do-snapserver
           image: riemerk/mr-do-snapserver:0.34.0
           imagePullPolicy: IfNotPresent
-          # snapserver uses $HOME/.config/snapserver for persistent settings.
-          # With runAsUser 1000 we point HOME at /home/snapserver so the
-          # volume mount can create the directory.
-          env:
-            - name: HOME
-              value: /home/snapserver
           ports:
             - containerPort: 1780
               name: webinterface
@@ -134,6 +128,11 @@ spec:
           env:
             - name: TZ
               value: Europe/Berlin
+            # snapserver uses $HOME/.config/snapserver for persistent settings.
+            # With runAsUser 1000 we point HOME at /home/snapserver so the
+            # volume mount can create the directory.
+            - name: HOME
+              value: /home/snapserver
           startupProbe:
             tcpSocket:
               port: 1705


### PR DESCRIPTION
Duplicate env: key caused YAML unmarshal error. Merge HOME into existing snapserver env block.