### PR TITLE
fix(player): snapserver mount path /root -> /home/snapserver for runA…

### DIFF
--- a/mr-do-player/kubernetes/deployment.yaml
+++ b/mr-do-player/kubernetes/deployment.yaml
@@ -157,7 +157,7 @@ spec:
           volumeMounts:
             # Requires /srv/nfs4/homes/mr/media/snapserver/ to exist on NFS
             - name: player-data
-              mountPath: /root/.config/snapserver
+              mountPath: /home/snapserver/.config/snapserver
               subPath: snapserver
             - name: snapserver-config
               mountPath: /etc/snapserver.conf


### PR DESCRIPTION
…sUser 1000

The deployment runs as UID 1000 (security hardening), but the snapserver volume mount pointed at /root/.config/snapserver which is owned by root. snapserver failed with 'failed to create persistent settings directory: //.config/snapserver/: 30 (EROFS)'. Mount to /home/snapserver instead so UID 1000 owns the home directory and can create the .config/snapserver subdir on the NFS share.