### PR TITLE
fix(player): set HOME=/home/snapserver so snapserver can create confi…

### DIFF
--- a/mr-do-player/kubernetes/deployment.yaml
+++ b/mr-do-player/kubernetes/deployment.yaml
@@ -110,6 +110,12 @@ spec:
         - name: mr-do-snapserver
           image: riemerk/mr-do-snapserver:0.34.0
           imagePullPolicy: IfNotPresent
+          # snapserver uses $HOME/.config/snapserver for persistent settings.
+          # With runAsUser 1000 we point HOME at /home/snapserver so the
+          # volume mount can create the directory.
+          env:
+            - name: HOME
+              value: /home/snapserver
           ports:
             - containerPort: 1780
               name: webinterface


### PR DESCRIPTION
…g dir

snapserver resolves its persistent settings directory as $HOME/.config/snapserver. Without HOME set, it expands to '/.config/snapserver' (note the double slash indicating empty HOME), which is unwritable for UID 1000.

Set HOME=/home/snapserver in the container env. Combined with the previous fix that mounts the NFS share at /home/snapserver/.config/snapserver, the settings directory now resolves correctly.