### PR TITLE
ci(client): scope workflow to mr-do-snapclient/ + workflow file

### DIFF
--- a/.github/workflows/docker-image-client.yml
+++ b/.github/workflows/docker-image-client.yml
@@ -4,8 +4,14 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main" ]
+    paths:
+      - 'mr-do-snapclient/**'
+      - '.github/workflows/docker-image-client.yml'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'mr-do-snapclient/**'
+      - '.github/workflows/docker-image-client.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Add paths: filter so the client image workflow only runs when mr-do-snapclient/ files or this workflow file itself change. Prevents unnecessary multi-arch Docker builds when other parts of the repo (e.g. Kubernetes manifests, other workflows) change.