### PR TITLE
fix: broaden secrets guard regex (case-insensitive)

### DIFF
--- a/scripts/check-no-secrets.sh
+++ b/scripts/check-no-secrets.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
-# CI guard: detect hardcoded secrets in Kubernetes manifests and last-applied-configuration annotations.
+# CI guard: detect hardcoded secrets in Kubernetes manifests and scripts.
 # Usage: ./scripts/check-no-secrets.sh [path-to-search]
-# Default search path: current directory.
-#
-# Blocks on:
-#   - literal "password" / "token" / "secret" in spec.values / spec.data blocks
-#   - any `kind: Secret` whose data values look base64-encoded high-entropy (i.e., not a config key)
-#   - hardcoded nfs.server IPs (env-specific drift risk)
-#
-# Designed to run as a pre-merge / GitHub-Actions step.
 set -euo pipefail
 
 SEARCH_PATH="${1:-.}"
@@ -21,7 +13,7 @@ fail=0
 
 echo "==> Scanning $SEARCH_PATH for hardcoded credentials..."
 
-# 1) Plain-text password / token / api_key values
+# 1) Plain-text password / token / api_key values in YAML
 if grep -rEn --include='*.yaml' --include='*.yml' \
     "(password|token|api[_-]?key|secret[_-]?key)\s*:\s*['\"]?[A-Za-z0-9+/=]{12,}" \
     "$SEARCH_PATH" 2>/dev/null; then
@@ -29,10 +21,13 @@ if grep -rEn --include='*.yaml' --include='*.yml' \
     fail=1
 fi
 
-# 2) Plain SSH / NFS passwords in shell scripts
-if grep -rEn 'password\s*=\s*["'\''][a-zA-Z0-9]{6,}["'\'']' --include='*.sh' --include='*.py' \
-    "$SEARCH_PATH" 2>/dev/null | grep -v -E '\.env|secret|temp|/tmp/'; then
-    echo -e "${RED}FAIL${NC}: hardcoded password-like literal in shell/python script"
+# 2) Plain-text passwords/auth/tokens in shell/python/conf/ini scripts
+# Case-insensitive to catch SSH_PASS, AUTH, TOKEN, etc.
+# Allows word chars between keyword and [:=] (e.g. SSH_PASS = "...", API_KEY="...")
+if grep -rEin --include='*.sh' --include='*.py' --include='*.conf' --include='*.ini' --include='*.cfg' \
+    '(pass|auth|token|secret|credential|api[_-]?key)[a-z_]*\s*[:=]\s*["'"'"'][a-zA-Z0-9:/_+=-]{6,}["'"'"']' \
+    "$SEARCH_PATH" 2>/dev/null | grep -v -E '\.env|getenv|environ|os\.environ|secretKeyRef|valueFrom|secretRef|<|YOUR_|CHANGE_ME|EXAMPLE|xxxx|placeholder|^\S*:#|^\S*:#'; then
+    echo -e "${RED}FAIL${NC}: hardcoded credential literal in script/config"
     fail=1
 fi
 
@@ -42,15 +37,14 @@ if grep -rEn --include='*.yaml' --include='*.yml' \
     echo "WARN: found Secret manifests — verify they use sealed-secrets/external-secrets and no plain values"
 fi
 
-# 4) Hardcoded NFS server IPs (drift risk per GLM 5.2 review I4)
+# 4) Hardcoded NFS server IPs (drift risk)
 if grep -rEn --include='*.yaml' --include='*.yml' \
     'server:\s*192\.168\.[0-9]+\.[0-9]+' "$SEARCH_PATH" 2>/dev/null; then
     echo -e "${RED}FAIL${NC}: hardcoded NFS server IP — use a hostname resolvable in the target cluster"
     fail=1
 fi
 
-# 5) last-applied-configuration annotations live in cluster only, not in Git
-# but if anyone commits a dump, the regex catches it
+# 5) last-applied-configuration annotations (live-state dumps)
 if grep -rEn 'kubectl.kubernetes.io/last-applied-configuration' \
     --include='*.yaml' --include='*.yml' "$SEARCH_PATH" 2>/dev/null; then
     echo -e "${RED}FAIL${NC}: committed live-state dump with last-applied-configuration annotation"


### PR DESCRIPTION
Per GLM 5.2 review: old regex was case-sensitive and missed SSH_PASS, AUTH, etc. Added -i flag.