### PR TITLE
fix: bump to mr-do-upnp-c:0.2.0 (Xvfb stale lock fix)

### DIFF
--- a/mr-do-player/kubernetes/deployment.yml
+++ b/mr-do-player/kubernetes/deployment.yml
@@ -67,7 +67,7 @@ spec:
           # Replaces the old gmediarender image (riemerk/mr-do-upnp).
           # Kodi uses xbmc/xbmc's own UPnP stack for max compatibility.
           image: riemerk/mr-do-upnp-c:0.2.0
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 49494
               name: upnp-http
@@ -79,20 +79,31 @@ spec:
               value: Europe/Berlin
             - name: UPNP_NAME
               value: mrCast
-          # Kodi takes ~20s to boot (Xvfb + GL init + skin load + UPnP start).
-          # Use a generous startup probe so K8s doesn't kill it before it's ready.
+          # Kodi takes ~20-30s to boot (Xvfb + GL init + skin load + UPnP).
+          # The UPnP HTTP port is dynamically assigned by Kodi's Platinum stack,
+          # so we can't probe a fixed TCP port.  Use an exec probe that checks
+          # the kodi.log for "starting upnp renderer" instead.
           startupProbe:
-            tcpSocket:
-              port: upnp-http
+            exec:
+              command:
+                - sh
+                - -c
+                - grep -q "starting upnp renderer" /tmp/kodi-home/.kodi/temp/kodi.log
             failureThreshold: 30
             periodSeconds: 5
           livenessProbe:
-            tcpSocket:
-              port: upnp-http
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f kodi-x11 >/dev/null
             periodSeconds: 30
           readinessProbe:
-            tcpSocket:
-              port: upnp-http
+            exec:
+              command:
+                - sh
+                - -c
+                - grep -q "starting upnp renderer" /tmp/kodi-home/.kodi/temp/kodi.log
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:

--- a/mr-do-player/kubernetes/deployment.yml
+++ b/mr-do-player/kubernetes/deployment.yml
@@ -66,7 +66,7 @@ spec:
           # Kodi/XBMC v21.3 headless UPnP/DLNA MediaRenderer (from mr-do-upnp-c).
           # Replaces the old gmediarender image (riemerk/mr-do-upnp).
           # Kodi uses xbmc/xbmc's own UPnP stack for max compatibility.
-          image: riemerk/mr-do-upnp-c:0.1.0
+          image: riemerk/mr-do-upnp-c:0.2.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 49494


### PR DESCRIPTION
0.1.0 crashes in K8s with CrashLoopBackOff — Xvfb fails because `/tmp/.X99-lock` persists across container restarts (emptyDir reused). 0.2.0 removes stale lock files before starting Xvfb.

Image already pushed to Docker Hub.