### PR TITLE
chore: remove last reference to deleted mr-do-upnp image

### DIFF
--- a/mr-do-player/kubernetes/deployment.yml
+++ b/mr-do-player/kubernetes/deployment.yml
@@ -64,7 +64,6 @@ spec:
       containers:
         - name: mr-do-upnp
           # Kodi/XBMC v21.3 headless UPnP/DLNA MediaRenderer (from mr-do-upnp-c).
-          # Replaces the old gmediarender image (riemerk/mr-do-upnp).
           # Kodi uses xbmc/xbmc's own UPnP stack for max compatibility.
           image: riemerk/mr-do-upnp-c:0.2.0
           imagePullPolicy: Always


### PR DESCRIPTION
Removes the last comment referencing the deleted `riemerk/mr-do-upnp` Docker Hub repo.