### PR TITLE
fix: liveness probe uses test instead of pgrep (not in image)

### DIFF
--- a/mr-do-player/kubernetes/deployment.yml
+++ b/mr-do-player/kubernetes/deployment.yml
@@ -95,7 +95,7 @@ spec:
               command:
                 - sh
                 - -c
-                - pgrep -f kodi-x11 >/dev/null
+                - test -f /tmp/kodi-home/.kodi/temp/kodi.log
             periodSeconds: 30
           readinessProbe:
             exec:


### PR DESCRIPTION
pgrep doesn't exist in the Debian-slim runtime image → liveness probe fails with `sh: 1: pgrep: not found` → CrashLoopBackOff.

Replace with `test -f /tmp/kodi-home/.kodi/temp/kodi.log` which always exists while Kodi runs.