### PR TITLE
fix: bump to mr-do-upnp-c:0.3.0

### DIFF
--- a/mr-do-player/kubernetes/deployment.yml
+++ b/mr-do-player/kubernetes/deployment.yml
@@ -65,7 +65,7 @@ spec:
         - name: mr-do-upnp
           # Kodi/XBMC v21.3 headless UPnP/DLNA MediaRenderer (from mr-do-upnp-c).
           # Kodi uses xbmc/xbmc's own UPnP stack for max compatibility.
-          image: riemerk/mr-do-upnp-c:0.2.0
+          image: riemerk/mr-do-upnp-c:0.3.0
           imagePullPolicy: Always
           ports:
             - containerPort: 49494


### PR DESCRIPTION
0.3.0 includes all MiniMax-M3 review fixes:
- ca-certificates (SSL HTTPS)
- mkfifo umask 0 (correct FIFO mode)
- awk instead of sed (UPNP_NAME injection)
- foreground kodi + wait (Xvfb cleanup)
- Xvfb loop-retry on X socket
- loglevel integer 3